### PR TITLE
Update Dockerfile to run as non-privileged user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,14 @@ MAINTAINER Carlo Eugster <carlo@relaun.ch>
 
 RUN  apt-get update \
   && apt-get install -y wget \
+  && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
+
+RUN useradd -m -d /opt/factorio -s /bin/bash factorio \
+  && chown -R factorio.factorio /opt/factorio
+USER factorio
+ENV HOME /opt/factorio
+WORKDIR /opt/factorio
 
 RUN  wget -q -O - https://www.factorio.com/download-headless/stable | grep -o -m1 "/get-download/.*/headless/linux64" | awk '{print "--no-check-certificate https://www.factorio.com"$1" -O /tmp/factorio.tar.gz"}' | xargs wget \
   && tar -xzf /tmp/factorio.tar.gz -C /opt \
@@ -12,5 +19,5 @@ RUN  wget -q -O - https://www.factorio.com/download-headless/stable | grep -o -m
 
 ADD  init.sh /opt/factorio/
 
-WORKDIR /opt/factorio
+EXPOSE 34197/udp
 CMD ["./init.sh"]

--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ docker run -d \
 Use a docker volume to persist the savegames on the host machine rather than in the docker container.
 
 ```bash
+mkdir $(pwd)/saves
+
+# Make sure the saves dir can be written to by the "factorio" user in Docker, with uid 1000
+sudo chown 1000:1000 $(pwd)/saves
+# (alternatively, if you don't have root): chmod 777 $(pwd)/saves
+
 docker run -d \
            -v $(pwd)/saves:/opt/factorio/saves \
            -p 34197:34197/udp \


### PR DESCRIPTION
I'd rather run factorio as a non-root user. However, I haven't been able to figure out how to do this and still be able to chown the volume in the container. I could do it by running init.sh as root and then using sudo or su to drop permissions before starting factorio, but that seems like an ugly hack. :(
