### PR TITLE
Added xz-utils and removed tar z-flag  for factorio-images with tar.xz

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:14.04
 MAINTAINER Carlo Eugster <carlo@relaun.ch>
 
 RUN  apt-get update \
-  && apt-get install -y wget \
+  && apt-get install -y wget xz-utils \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 
@@ -17,7 +17,7 @@ ENV SAVEFILE /opt/factorio/saves/factorio_save.zip
 WORKDIR /opt/factorio
 
 RUN  wget -q -O - https://www.factorio.com/download-headless/stable | grep -o -m1 "/get-download/.*/headless/linux64" | awk '{print "--no-check-certificate https://www.factorio.com"$1" -O /tmp/factorio.tar.gz"}' | xargs wget \
-  && tar -xzf /tmp/factorio.tar.gz -C /opt \
+  && tar -xf /tmp/factorio.tar.gz -C /opt \
   && rm -rf /tmp/factorio.tar.gz
 
 ADD  init.sh /opt/factorio/


### PR DESCRIPTION
As described on factorio.com, the archive can be either tar.gz or tar.xz.
Tar is able to recognize the format automatically if you dismiss the -z parameter but you need xz-utils installed on your maschine. This is fixing the Issue #4.



`0.14.23 (headless)
Stripped down version of the game for running servers on machines without graphical interface.

Generic Linux tar package (64 .tar.gz or .tar.xz)
compatible with Linux`

https://www.factorio.com/download-headless/experimental

